### PR TITLE
Separate scale()/scaleWithOffset()

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -408,14 +408,14 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
         //      scrolling once with delta 2x. Someone with the ability to test this code might want to "upgrade" it.
         const int delta = pixels.y();
         const qreal newScale = currentScale * (1 + (delta * 0.01));
-        mEditor->view()->scale(newScale, offset);
+        mEditor->view()->scaleWithOffset(newScale, offset);
     }
     else if (!angle.isNull())
     {
         const int delta = angle.y();
         // 12 rotation steps at "standard" wheel resolution (120/step) result in 100x zoom
         const qreal newScale = currentScale * std::pow(100, delta / (12.0 * 120));
-        mEditor->view()->scale(newScale, offset);
+        mEditor->view()->scaleWithOffset(newScale, offset);
     }
     updateCanvasCursor();
     event->accept();

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
@@ -275,7 +275,7 @@ void ViewManager::scale25()
     scale(0.25);
 }
 
-void ViewManager::scale(qreal scaleValue, QPointF offset)
+void ViewManager::scale(qreal scaleValue)
 {
     if (scaleValue < mMinScale)
     {
@@ -288,7 +288,27 @@ void ViewManager::scale(qreal scaleValue, QPointF offset)
 
     if (mCurrentCamera)
     {
-        mCurrentCamera->scale(scaleValue, offset);
+        mCurrentCamera->scale(scaleValue);
+        updateViewTransforms();
+
+        Q_EMIT viewChanged();
+    }
+}
+
+void ViewManager::scaleWithOffset(qreal scaleValue, QPointF offset)
+{
+    if (scaleValue < mMinScale)
+    {
+        scaleValue = mMinScale;
+    }
+    else if (scaleValue > mMaxScale)
+    {
+        scaleValue = mMaxScale;
+    }
+
+    if (mCurrentCamera)
+    {
+        mCurrentCamera->scaleWithOffset(scaleValue, offset);
         updateViewTransforms();
 
         Q_EMIT viewChanged();

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
@@ -63,7 +63,8 @@ public:
     void rotate(float degree);
 
     qreal scaling();
-    void scale(qreal scaleValue, QPointF offset = {0, 0});
+    void scale(qreal scaleValue);
+    void scaleWithOffset(qreal scaleValue, QPointF offset);
     void scaleUp();
     void scaleDown();
     void scale400();

--- a/core_lib/src/structure/camera.cpp
+++ b/core_lib/src/structure/camera.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2012-2018 Matthew Chiawen Chang
@@ -120,11 +120,17 @@ void Camera::rotate(qreal degree)
     modification();
 }
 
-void Camera::scale(qreal scaleValue, QPointF offset)
+void Camera::scale(qreal scaleValue)
 {
-    if (!offset.isNull()) {
-        mTranslate = (mTranslate + offset) * mScale / scaleValue - offset;
-    }
+    mScale = scaleValue;
+
+    mNeedUpdateView = true;
+    modification();
+}
+
+void Camera::scaleWithOffset(qreal scaleValue, QPointF offset)
+{
+    mTranslate = (mTranslate + offset) * mScale / scaleValue - offset;
     mScale = scaleValue;
 
     mNeedUpdateView = true;

--- a/core_lib/src/structure/camera.h
+++ b/core_lib/src/structure/camera.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2012-2018 Matthew Chiawen Chang
@@ -43,7 +43,8 @@ public:
     void rotate(qreal degree);
     qreal rotation() { return mRotate; }
 
-    void scale(qreal scaleValue, QPointF offset = {0, 0});
+    void scale(qreal scaleValue);
+    void scaleWithOffset(qreal scaleValue, QPointF offset); // for zooming at the mouse position
     qreal scaling() { return mScale; }
 
     QTransform view;

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
@@ -117,6 +117,6 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
     {
         float delta = (static_cast<float>(getCurrentPixel().y() - mLastPixel.y())) / 100.f;
         qreal scaleValue = viewMgr->scaling() * (1 + delta);
-        viewMgr->scale(scaleValue, mStartPoint);
+        viewMgr->scaleWithOffset(scaleValue, mStartPoint);
     }
 }


### PR DESCRIPTION
Having two separated functions `scale()` & `scaleWithOffset()` to clearly indicate what the functions do