### PR TITLE
Changes for #1442

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -80,7 +80,8 @@ HEADERS += \
     src/presetdialog.h \
     src/commandlineparser.h \
     src/commandlineexporter.h \
-    src/statusbar.h
+    src/statusbar.h \
+    src/elidedlabel.h
 
 SOURCES += \
     src/importlayersdialog.cpp \
@@ -124,7 +125,8 @@ SOURCES += \
     src/app_util.cpp \
     src/commandlineparser.cpp \
     src/commandlineexporter.cpp \
-    src/statusbar.cpp
+    src/statusbar.cpp \
+    src/elidedlabel.cpp
 
 FORMS += \
     ui/importimageseqpreview.ui \

--- a/app/src/elidedlabel.cpp
+++ b/app/src/elidedlabel.cpp
@@ -1,0 +1,132 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "elidedlabel.h"
+
+#include <QPainter>
+#include <QSizePolicy>
+#include <QTextLayout>
+
+
+ElidedLabel::ElidedLabel(QWidget *parent)
+    : QFrame(parent)
+    , elided(false)
+{
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+}
+
+//! [0]
+ElidedLabel::ElidedLabel(const QString &text, QWidget *parent) :
+    ElidedLabel(parent)
+{
+    content = text;
+}
+//! [0]
+
+//! [1]
+void ElidedLabel::setText(const QString &newText)
+{
+    content = newText;
+    update();
+}
+//! [1]
+
+QSize ElidedLabel::sizeHint() const
+{
+    return fontMetrics().size(0, content);
+}
+
+//! [2]
+void ElidedLabel::paintEvent(QPaintEvent *event)
+{
+    QFrame::paintEvent(event);
+
+    QPainter painter(this);
+    QFontMetrics fontMetrics = painter.fontMetrics();
+
+    bool didElide = false;
+    int lineSpacing = fontMetrics.lineSpacing();
+    int y = 0;
+
+    QTextLayout textLayout(content, painter.font());
+    textLayout.beginLayout();
+    forever {
+        QTextLine line = textLayout.createLine();
+
+        if (!line.isValid())
+            break;
+
+        line.setLineWidth(width());
+        int nextLineY = y + lineSpacing;
+
+        if (height() >= nextLineY + lineSpacing) {
+            line.draw(&painter, QPoint(0, y));
+            y = nextLineY;
+            //! [2]
+            //! [3]
+        } else {
+            QString lastLine = content.mid(line.textStart());
+            QString elidedLastLine = fontMetrics.elidedText(lastLine, Qt::ElideRight, width());
+            painter.drawText(QPoint(0, y + fontMetrics.ascent()), elidedLastLine);
+            line = textLayout.createLine();
+            didElide = line.isValid();
+            break;
+        }
+    }
+    textLayout.endLayout();
+    //! [3]
+
+    //! [4]
+    if (didElide != elided) {
+        elided = didElide;
+        emit elisionChanged(didElide);
+    }
+}
+//! [4]

--- a/app/src/elidedlabel.h
+++ b/app/src/elidedlabel.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef ELIDEDLABEL_H
+#define ELIDEDLABEL_H
+
+#include <QFrame>
+#include <QString>
+
+//! [0]
+class ElidedLabel : public QFrame
+{
+    Q_OBJECT
+    Q_PROPERTY(QString text READ text WRITE setText)
+    Q_PROPERTY(bool isElided READ isElided)
+
+public:
+    explicit ElidedLabel(QWidget *parent = nullptr);
+    explicit ElidedLabel(const QString &text, QWidget *parent = nullptr);
+
+    void setText(const QString &text);
+    const QString & text() const { return content; }
+    bool isElided() const { return elided; }
+
+    virtual QSize sizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+signals:
+    void elisionChanged(bool elided);
+
+private:
+    bool elided;
+    QString content;
+};
+//! [0]
+
+#endif // TEXTWRAPPINGWIDGET_H

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -424,8 +424,9 @@ void MainWindow2::setOpacity(int opacity)
 
 void MainWindow2::updateSaveState()
 {
-    setWindowModified(mEditor->currentBackup() != mBackupAtSave);
-    ui->statusBar->updateModifiedStatus(mEditor->currentBackup() != mBackupAtSave);
+    const bool hasUnsavedChanges = mEditor->currentBackup() != mBackupAtSave;
+    setWindowModified(hasUnsavedChanges);
+    ui->statusBar->updateModifiedStatus(hasUnsavedChanges);
 }
 
 void MainWindow2::clearRecentFilesList()

--- a/app/src/statusbar.cpp
+++ b/app/src/statusbar.cpp
@@ -35,6 +35,7 @@ StatusBar::StatusBar(QWidget *parent) : QStatusBar(parent)
     mToolIcon = new QLabel(this);
     addWidget(mToolIcon);
     mToolLabel = new ElidedLabel(this);
+    mToolLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     addWidget(mToolLabel, 1);
 
     mModifiedLabel = new QLabel(this);

--- a/app/src/statusbar.cpp
+++ b/app/src/statusbar.cpp
@@ -150,9 +150,11 @@ void StatusBar::updateModifiedStatus(bool modified)
     if (modified)
     {
         mModifiedLabel->setToolTip(tr("This file has unsaved changes"));
-        return;
     }
-    mModifiedLabel->setToolTip(tr("This file has no unsaved changes"));
+    else
+    {
+        mModifiedLabel->setToolTip(tr("This file has no unsaved changes"));
+    }
 }
 
 void StatusBar::updateZoomStatus()

--- a/app/src/statusbar.cpp
+++ b/app/src/statusbar.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <QLineEdit>
 
 #include "editor.h"
+#include "elidedlabel.h"
 #include "layermanager.h"
 #include "scribblearea.h"
 #include "toolmanager.h"
@@ -33,8 +34,8 @@ StatusBar::StatusBar(QWidget *parent) : QStatusBar(parent)
 
     mToolIcon = new QLabel(this);
     addWidget(mToolIcon);
-    mToolLabel = new QLabel(this);
-    addWidget(mToolLabel);
+    mToolLabel = new ElidedLabel(this);
+    addWidget(mToolLabel, 1);
 
     mModifiedLabel = new QLabel(this);
     mModifiedLabel->setPixmap(QPixmap(":/icons/save.png"));

--- a/app/src/statusbar.cpp
+++ b/app/src/statusbar.cpp
@@ -48,7 +48,7 @@ StatusBar::StatusBar(QWidget *parent) : QStatusBar(parent)
     mZoomBox->setMaxCount(mZoomBox->count() + 1);
     mZoomBox->setEditable(true);
     mZoomBox->lineEdit()->setAlignment(Qt::AlignRight);
-    connect(mZoomBox, QOverload<const QString &>::of(&QComboBox::activated), [this](const QString &currentText)
+    connect(mZoomBox, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated), [this](const QString &currentText)
     {
         if (mZoomBox->count() == mZoomBox->maxCount())
         {

--- a/app/src/statusbar.h
+++ b/app/src/statusbar.h
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include "pencildef.h"
 
 class Editor;
+class ElidedLabel;
 class QComboBox;
 class QLabel;
 class QSlider;
@@ -86,7 +87,7 @@ private:
     /** Label used to display the icon of the current tool */
     QLabel *mToolIcon = nullptr;
     /** Label used to display a short help text for the current tool */
-    QLabel *mToolLabel = nullptr;
+    ElidedLabel *mToolLabel = nullptr;
     /** Label indicating that the current file contains unsaved changes */
     QLabel *mModifiedLabel = nullptr;
     /** Combo box for choosing pre-defined or custom zoom levels */

--- a/app/src/statusbar.h
+++ b/app/src/statusbar.h
@@ -39,7 +39,7 @@ public:
      *
      * @param parent The parent object of the status bar
      */
-    explicit StatusBar(QWidget *parent);
+    explicit StatusBar(QWidget *parent = nullptr);
 
     /**
      * Associates an Editor instance with the status bar.


### PR DESCRIPTION
Here are a couple of changes for your PR #1442. The biggest thing is moving the tool tips to a custom label implementation that allows for it to be cut off with ellipses if there is not enough space. If we don't do this or something like this, the status bar ends up restricting the minimum width of the window to a sometimes much larger width than previously.